### PR TITLE
fixed spacing problems on team roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ At the end of the six weeks, we aim to deliver:
 [Project wiki](https://github.com/18F/18f-education-discovery/wiki)
 
 ##Team members
-Victor Udoewa – Product owner
-Jeremy Zilar — Engagement manager
-Carolyn Dew — Research lead
-Lane Becker — Researcher and strategist
-Jen Ehlers – Researcher
+- Victor Udoewa – Product owner
+- Jeremy Zilar — Engagement manager
+- Carolyn Dew — Research lead
+- Lane Becker — Researcher and strategist
+- Jen Ehlers – Researcher
 
 ##License information
 


### PR DESCRIPTION
Previously the team members were showing up as a paragraph in a jumble, now they appear in an bulleted list. 
